### PR TITLE
Don't directly touch AC::Base, but do it via AS.on_load in the Railtie

### DIFF
--- a/lib/weak_parameters.rb
+++ b/lib/weak_parameters.rb
@@ -49,6 +49,12 @@ module WeakParameters
       hash[key] = ActiveSupport::HashWithIndifferentAccess.new
     end
   end
-end
 
-ActionController::Base.extend WeakParameters::Controller
+  class Railties < ::Rails::Railtie
+    initializer 'weak_parameters' do
+      ActiveSupport.on_load :action_controller do
+        ActionController::Base.extend WeakParameters::Controller
+      end
+    end
+  end
+end


### PR DESCRIPTION
Otherwise, requiring this gem (usually via Bundler) will immediately load AC::Base and trigger its initializers.
