### PR TITLE
Validator should better respond to `params` for backward compat

### DIFF
--- a/lib/weak_parameters/validator.rb
+++ b/lib/weak_parameters/validator.rb
@@ -17,6 +17,10 @@ module WeakParameters
 
     private
 
+    def params
+      controller.params
+    end
+
     def any(key, options = {}, &block)
       validators << WeakParameters::AnyValidator.new(controller, key, options, &block)
     end


### PR DESCRIPTION
684651d264069f01066de9946cc23079583934dd replaced `params` accessor into `controller` in BaseValidator and Validator, then added `params` method back to only BaseValidator.

This caused

```
NameError (undefined local variable or method `params' for #<WeakParameters::Validator:0x007fc04af9b020>)
```

in our existing code.
