### PR TITLE
Support nested param

### DIFF
--- a/lib/weak_parameters/base_validator.rb
+++ b/lib/weak_parameters/base_validator.rb
@@ -61,8 +61,12 @@ module WeakParameters
       controller.params
     end
 
+    NESTED_KEY_REGEXP = /\[?([^\[\]]+)\]?/
+
     def value
-      params[key]
+      @value ||= key.to_s.scan(NESTED_KEY_REGEXP).flatten.inject(params) do |param, key|
+        param[key] if param
+      end
     end
 
     def handle_failure

--- a/spec/dummy/app/controllers/recipes_controller.rb
+++ b/spec/dummy/app/controllers/recipes_controller.rb
@@ -13,6 +13,7 @@ class RecipesController < ApplicationController
     string :zip_code do |value|
       value =~ /\A\d{3}-\d{4}\z/
     end
+    string "message[body]", required: true
   end
 
   def create

--- a/spec/requests/recipes_spec.rb
+++ b/spec/requests/recipes_spec.rb
@@ -13,6 +13,7 @@ describe "Recipes" do
       attachment: Rack::Test::UploadedFile.new(__FILE__),
       zip_code: "123-4567",
       custom: 0,
+      message: { body: "body" },
     }
   end
 
@@ -97,6 +98,13 @@ describe "Recipes" do
     context "with block failure" do
       before do
         params[:zip_code] = "123-456"
+      end
+      include_examples "400"
+    end
+
+    context "without nested required param" do
+      before do
+        params[:message].delete(:body)
       end
       include_examples "400"
     end


### PR DESCRIPTION
### Usage

```ruby
validates :create do
  string "message[body]", required: true
end
```

I’m not sure the implementation is acceptable, especially regexp. :sweat: 
It would be helpful if you check and review.