### PR TITLE
Replace before_filter with prepend_before_filter

### DIFF
--- a/lib/weak_parameters/controller.rb
+++ b/lib/weak_parameters/controller.rb
@@ -1,7 +1,7 @@
 module WeakParameters
   module Controller
     def validates(action_name, &block)
-      before_filter only: action_name do
+      prepend_before_filter only: action_name do
         validator = WeakParameters::Validator.new(self, &block)
         WeakParameters.stats[params[:controller]][params[:action]] = validator
         WeakParameters.stats[params[:controller]][params[:action]].validate


### PR DESCRIPTION
By using before_filter, `validates` method should be called before
other before_filter. This makes unspoken rule for method calling.
So changes to prepend_before_filter.
