### PR TITLE
autodoc + weak_parametersで2つ以上、invalidなパラメータがあった場合にドキュメント生成に失敗する

### DIFF
--- a/lib/weak_parameters/base_validator.rb
+++ b/lib/weak_parameters/base_validator.rb
@@ -7,6 +7,7 @@ module WeakParameters
       @key = key
       @options = options
       @block = block
+      @path = []
     end
 
     def validate(*path)


### PR DESCRIPTION
# 発生条件

- weak_parameters 0.1.6
- 2つ以上invalidなパラメータがある

## 再現させたコード

https://github.com/taka0125/autodoc_failed_sample

# エラー内容

```
xxx/weak_parameters-0.1.6/lib/weak_parameters/base_validator.rb:73:in `path': undefined method `+' for nil:NilClass (NoMethodError)
	from xxx/weak_parameters-0.1.6/lib/weak_parameters/base_validator.rb:27:in `key'
	from xxx/autodoc-0.4.3/lib/autodoc/document.rb:239:in `body'
```

# 原因

2つ以上invalidだと、1つ目のバリデーションで`WeakParameters::ValidationError`が`raise`されて2つ目以降の`validator`の`validate`は呼ばれない

その為、`validate`メソッド内で初期化している`path`は`nil`のまま

その状態で、`path`にアクセスがあったので落ちる

※ `autodoc`側で対応するより`weak_parameters`側で対応する方が楽＆安全だと思ったのでプルリクを出しました。