### PR TITLE
:bug: Fix exist? method

### DIFF
--- a/lib/weak_parameters/base_validator.rb
+++ b/lib/weak_parameters/base_validator.rb
@@ -54,7 +54,7 @@ module WeakParameters
     end
 
     def nil?
-      value.nil?
+      params[key].nil?
     end
 
     def exist?

--- a/spec/requests/recipes_spec.rb
+++ b/spec/requests/recipes_spec.rb
@@ -64,7 +64,7 @@ describe "Recipes", type: :request do
 
     context "with exceptional interger param" do
       before do
-        params[:number] = true
+        params[:number] = [1]
       end
       include_examples "400"
     end


### PR DESCRIPTION
IntegerValidator#exist? does not work when value not have #to_i method.
(ex. Array)
https://github.com/r7kamura/weak_parameters/blob/master/lib/weak_parameters/base_validator.rb#L60


IntegerValidator#value use `try(to_i)`.
it's return nil.

https://github.com/r7kamura/weak_parameters/blob/master/lib/weak_parameters/integer_validator.rb#L13

