### PR TITLE
fix BaseValidator#nil? for nested parameters

### DIFF
--- a/lib/weak_parameters/base_validator.rb
+++ b/lib/weak_parameters/base_validator.rb
@@ -54,7 +54,7 @@ module WeakParameters
     end
 
     def nil?
-      params[key].nil?
+      params.nil? || params[key].nil?
     end
 
     def exist?

--- a/spec/requests/recipes_spec.rb
+++ b/spec/requests/recipes_spec.rb
@@ -170,10 +170,19 @@ describe "Recipes", type: :request do
     end
 
     context "with complex params" do
-      before do
-        params[:body][:items] << { price: "xxx" }
+      describe 'invalid parameter' do
+        before do
+          params[:body][:items] << { price: "xxx" }
+        end
+        include_examples "400"
       end
-      include_examples "400"
+
+      describe 'missing parameter' do
+        before do
+          params.delete :body
+        end
+        include_examples "201"
+      end
     end
   end
 end


### PR DESCRIPTION
https://github.com/r7kamura/weak_parameters/pull/17 is not enough for nested parameters.

At nested parameters, `params` might be `nil`. So, could not use `[]` directly.