### PR TITLE
Use before_action instead of before_filter

### DIFF
--- a/lib/weak_parameters/controller.rb
+++ b/lib/weak_parameters/controller.rb
@@ -1,7 +1,7 @@
 module WeakParameters
   module Controller
     def validates(action_name, &block)
-      before_filter only: action_name do
+      before_action only: action_name do
         validator = WeakParameters::Validator.new(self, &block)
         WeakParameters.stats[params[:controller]][params[:action]] = validator
         WeakParameters.stats[params[:controller]][params[:action]].validate

--- a/weak_parameters.gemspec
+++ b/weak_parameters.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rails", ">= 3.2.11"
+  spec.add_dependency "rails", ">= 4.0.0"
   spec.add_development_dependency "autodoc"
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "pry-rails"


### PR DESCRIPTION
I want to resolve the following deprecation warning.

```
DEPRECATION WARNING: before_filter is deprecated and will be removed in
Rails 5.1. Use before_action instead.
```