### PR TITLE
Add support allow blank option

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ irb(main):005:0> app.post "/recipes", name: "alice", type: "bob"
 * except
 * handler
 * strong
+* allow_blank
 
 ## Tips
 WeakParameters.stats returns its validation metadata, and this is useful for auto-generating API documents.

--- a/lib/weak_parameters/base_validator.rb
+++ b/lib/weak_parameters/base_validator.rb
@@ -23,6 +23,10 @@ module WeakParameters
       !!options[:strong]
     end
 
+    def allow_blank?
+      !!options[:allow_blank]
+    end
+
     def type
       self.class.name.split("::").last.sub(/Validator$/, "").underscore.to_sym
     end
@@ -39,6 +43,8 @@ module WeakParameters
     private
 
     def valid?
+      return true if allow_blank? && blank?
+
       case
       when required? && nil?
         false
@@ -55,6 +61,10 @@ module WeakParameters
 
     def nil?
       params.nil? || params[key].nil?
+    end
+
+    def blank?
+      params.blank? || params[key].blank?
     end
 
     def exist?

--- a/spec/dummy/app/controllers/concerns/with_recipe.rb
+++ b/spec/dummy/app/controllers/concerns/with_recipe.rb
@@ -19,6 +19,9 @@ module WithRecipe
       object :nested, required: true do
         integer :number, only: [0, 1]
       end
+      string :point, allow_blank: true do |_|
+        false
+      end
 
       list :numbers, :integer, description: 'some numbers'
 

--- a/spec/requests/api/recipes_spec.rb
+++ b/spec/requests/api/recipes_spec.rb
@@ -153,6 +153,10 @@ describe "Recipes with rails-api", type: :request do
       include_examples "400"
     end
 
+    context "with blank option" do
+      include_examples "201"
+    end
+
     context "with wrong repeated params" do
       describe 'scalar' do
         before do

--- a/spec/requests/recipes_spec.rb
+++ b/spec/requests/recipes_spec.rb
@@ -16,6 +16,7 @@ describe "Recipes", type: :request do
       nested: {
         number: 0
       },
+      point: '',
       numbers: [1, 2, 3],
       body: {
         items: [
@@ -151,6 +152,10 @@ describe "Recipes", type: :request do
         params[:nested][:number] = true
       end
       include_examples "400"
+    end
+
+    context "with blank option" do
+      include_examples "201"
     end
 
     context "with wrong repeated params" do


### PR DESCRIPTION
In the most part, Rails has empty value if input value is empty with the form.
So, user must be conscious of blank value within the block.

I add support `allow_blank` option.


thank you