### PR TITLE
Change parameter name :only to :format in Time and Date

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ class RecipesController < ApplicationController
     string :quantity do |value|
       value =~ /\A\d+(?:\.\d+)g\z/
     end
-    date :date, only: ["%Y/%m/%d", "%Y.%m.%d"]
-    time :time, only: "%Y/%m/%d %H:%M:%S"
+    date :date, format: ["%Y/%m/%d", "%Y.%m.%d"]
+    time :time, format: "%Y/%m/%d %H:%M:%S"
   end
 
   def create
@@ -70,6 +70,7 @@ irb(main):005:0> app.post "/recipes", name: "alice", type: "bob"
 * except
 * handler
 * strong
+* format (only for date and time)
 
 ## Tips
 WeakParameters.stats returns its validation metadata, and this is useful for auto-generating API documents.

--- a/lib/weak_parameters/date_validator.rb
+++ b/lib/weak_parameters/date_validator.rb
@@ -7,8 +7,8 @@ module WeakParameters
     end
 
     def valid_type?
-      if options[:only]
-        Array(options[:only]).any? do |format|
+      if options[:format]
+        Array(options[:format]).any? do |format|
           begin
             parser_class.strptime(value, format)
             return false unless strictly?(format)

--- a/spec/dummy/app/controllers/concerns/with_recipe.rb
+++ b/spec/dummy/app/controllers/concerns/with_recipe.rb
@@ -12,9 +12,9 @@ module WithRecipe
       array :tags
       float :rate
       date :date
-      date :custom_date, only: %w[%Y/%m/%d %Y.%m.%d]
+      date :custom_date, format: %w[%Y/%m/%d %Y.%m.%d]
       time :time
-      time :custom_time, only: '%Y/%m/%d %H:%M:%S'
+      time :custom_time, format: '%Y/%m/%d %H:%M:%S'
       file :attachment
       integer :custom, only: 0..1, handler: :render_error
       string :zip_code do |value|

--- a/spec/requests/recipes_spec.rb
+++ b/spec/requests/recipes_spec.rb
@@ -120,11 +120,25 @@ describe "Recipes", type: :request do
       include_examples "400"
     end
 
+    context "with valid custom_date param" do
+      before do
+        params[:custom_date] = Date.current.strftime('%Y/%m/%d')
+      end
+      include_examples "201"
+    end
+
     context "with wrong time param" do
       before do
         params[:time] = '2017-01-31 24:00:01'
       end
       include_examples "400"
+    end
+
+    context "with valid time param" do
+      before do
+        params[:custom_time] = Time.current.strftime('%Y/%m/%d %H:%M:%S')
+      end
+      include_examples "201"
     end
 
     context "with wrong custom_time param" do


### PR DESCRIPTION
In `DateValidator` and `TimeValidator`, :only and :except semantics are
different from BaseValidator.
`BaseValidator`#exceptional? checks whether including or excluding
a value specified in :only and :except parameters.
But `DateValidator` and `TimeValidator` uses these parameters as a format
of time stamp. So I believe that a value returned by (DateValidator|TimeValidator)#exceptional  is always `false`.

What do you think? @r7kamura 